### PR TITLE
Avoid eslint import/first error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ import {
 } from 'admin-on-rest/mui'
 
 import tinymce from 'tinymce/tinymce'
-// react-tinymce use global ref
-window.tinymce = tinymce
 
 import 'tinymce/themes/modern/theme'
 import 'tinymce/skins/lightgray/skin.min.css'
 
 import TinyMCEInput from 'aor-tinymce-input'
+
+// react-tinymce use global ref
+window.tinymce = tinymce
 
 export const PostEdit = (props) => (
   <Edit>


### PR DESCRIPTION
react-script use eslint and the following error occured with readme sample code.

Here is a fix in order to avoid this error